### PR TITLE
Update the MyIP page to work with the v4 API, displaying data about all Beast/MLAT records not just the first one.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+[*.html]
+indent_style = space
+indent_size = 2

--- a/html/myip/index.html
+++ b/html/myip/index.html
@@ -5,20 +5,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OARC ADS-B Tracker - Feed Checker/Stats</title>
   <link rel="stylesheet" href="style.css">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 </head>
 
-<body onload="getapidata()">
-  <script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
-  <script src="index.js"></script>
+<body>
+<script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
+        crossorigin="anonymous"></script>
 
-<div id ="toplogo"><img src="topbanner.png" alt="top banner logo"></div>
+<div id="toplogo"><img src="topbanner.png" alt="top banner logo"></div>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Site Navigation</a>
-  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 
@@ -58,62 +61,75 @@
 <div class="container">
   <div class="row">
     <div class="col-sm">
-<div id="header">
-  <h1>Feed Checker/Stats<br /><div style="display: inline;" id="beastcount">&nbsp;</div> Beast feeds | <div style="display: inline;" id="mlatcount">&nbsp;</div> MLAT feeds</h1>
-</div>
+      <div id="header">
+        <h1>
+          Feed Checker/Stats<br/>
+          <span class="small font-monospace">
+            <span id="beastcount">?</span> Beast feeds |
+            <span id="mlatcount">?</span> MLAT feeds
+          </span>
+        </h1>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="container">
+  <div class="row mb-4">
+    <div class="col-sm">
+      <div id="userinfo">
+        Your IP: <code id="userip">Not yet fetched from API</code>
+      </div>
+    </div>
+  </div>
+
+  <div class="row gy-4" id="status_rows">
+    <div class="col">
+      <p class="alert alert-danger">
+        JavaScript is disabled or there has been an error which prevents JavaScript from running.
+        <br/>
+        Enable JavaScript to view IP stats and/or report suspected issues via the OARC Discord.
+      </p>
+    </div>
+  </div>
+
   <div class="row">
     <div class="col-sm">
-
-<div id="beaststatspanel">
-  <h2><span class="beastdot"></span> Beast ADS-B</h2>
-  <div id="beaststats">
-    <ul>
-      <li>Messages: <div style="display: inline;" id="msgsec">&nbsp;</div>/sec</li>
-      <li>Positions: <div style="display: inline;" id="possec">&nbsp;</div>/sec</li>
-      <li>Positions total: <div style="display: inline;" id="postotal">&nbsp;</div></li>
-      <li>Bandwidth: <div style="display: inline;" id="bandwidth">&nbsp;</div> kbit/s</li>
-      <li>Latency: <div style="display: inline;" id="latency">&nbsp;</div> ms</li>
-    </ul>
-  </div>
-  <div id="beaststatus"></div>
-</div>
-
-    </div>
-    <div class="col-sm">
-
-<div id="mlatstatspanel">
-  <h2><span class="mlatdot"></span> MLAT</h2>
-  <div id="mlatstats">
-    <ul>
-      <li>Name: <div style="display: inline;" id="mlatusername">&nbsp;</div></li>
-      <li>Messages: <div style="display: inline;" id="mlatmsgrate">&nbsp;</div>/sec</li>
-      <li>Peers: <div style="display: inline;" id="mlatpeers">&nbsp;</div></li>
-      <li>Timeout: <div style="display: inline;" id="mlattimeout">&nbsp;</div></li>
-      <li>Outlier %: <div style="display: inline;" id="mlatoutlier">&nbsp;</div></li>
-    </ul>
-  </div>
-  <div id="mlatstatus"></div>
-</div>
-
+      <div id="bottomtext">
+        <p>
+          Busted Beast latency display? Make sure you're feeding beast_reduce_plus_out data - you can
+          <a href="https://github.com/mpentler/oarc-adsb-scripts">reinstall the feed client</a>
+          to make sure of this.
+        </p>
+      </div>
     </div>
   </div>
 </div>
 
-<div class="container">
-<div class="row">
-<div class="col-sm">
-<div id="bottomtext">
-  <p>Busted Beast latency display? Make sure you're feeding beast_reduce_plus_out data - you can <a href="https://github.com/mpentler/oarc-adsb-scripts">reinstall the feed client</a> to make sure of this.</p>
-</div>
-    </div>
-  </div>
-</div>
+<script src="index.js"></script>
+<script>
+  /*
+    NOTE:
+    - The linked JS file contains functions only.
+    - This code segment actually "does stuff" / calls the functions.
+  */
 
+  // // URLs to the API data - these two relative URLs are useful for testing locally
+  // // if you paste a copy of the API output in your working directory.
+  // const apiUrlIp = 'myip_v4.json';
+  // const apiUrlFeedCount = 'feedcount.json';
+
+  // URLs to the API data - these are the real URLs for the live site.
+  const apiUrlIp = 'https://adsb.oarc.uk/api/v4/myip';
+  const apiUrlFeedCount = 'https://adsb.oarc.uk/api/v3/feedcount';
+
+  // Trigger the first update ASAP
+  getApiData(apiUrlIp, apiUrlFeedCount);
+
+  // ...then periodically refresh the data.
+  let updateFrequencyMs = 10 * 1000;
+  let intervalID = setInterval(() => {
+      getApiData(apiUrlIp, apiUrlFeedCount);
+  }, updateFrequencyMs);
+</script>
 </body>
 
 </html>

--- a/html/myip/index.js
+++ b/html/myip/index.js
@@ -1,66 +1,173 @@
 // Defining async function
-async function getapidata() {
+async function getApiData(apiUrlIp, apiUrlFeedCount) {
 
     // First the user stats...
     // Storing response
-    const response1 = await fetch("https://adsb.oarc.uk/api/v3/myip");
+    const userStatsResponse = await fetch(apiUrlIp);
 
     // Storing data in form of JSON
-    var userdata = await response1.json();
-    showuserstats(userdata);
+    const userData = await userStatsResponse.json();
+    updateUserStats(userData);
 
     // Now site stats...
     // Storing response
-    const response2 = await fetch("https://adsb.oarc.uk/api/v3/feedcount");
+    const siteStatsResponse = await fetch(apiUrlFeedCount);
 
     // Storing data in form of JSON
-    var sitedata = await response2.json();
-    showsitestats(sitedata);
+    const siteData = await siteStatsResponse.json();
+    updateSiteStats(siteData);
 }
 
-// Calling that async function
-let intervalID = setInterval(() => {
-        getapidata();
-}, 10000);
 
+function secondsToDhms(seconds) {
+    seconds = Number(seconds);
+    const d = Math.floor(seconds / (3600 * 24));
+    const h = Math.floor(seconds % (3600 * 24) / 3600);
+    const m = Math.floor(seconds % 3600 / 60);
+    const s = Math.floor(seconds % 60);
 
-// Function to update both stats panels
-function showuserstats(data) {
-    //Beast data
-    if (data[0] == "No match!") {
-        document.getElementsByClassName("beastdot")[0].style.backgroundColor = "red";
-        document.getElementById("beaststats").hidden = true;
-        document.getElementById("beaststatus").innerHTML = "You are not feeding Beast data!";
-    } else {
-        document.getElementsByClassName("beastdot")[0].style.backgroundColor = "green";
-        document.getElementById("beaststats").hidden = false;
-        document.getElementById("beaststatus").innerHTML = "You are feeding Beast data!";
-        document.getElementById("bandwidth").innerHTML = data[0][2];
-        document.getElementById("msgsec").innerHTML = data[0][4];
-        document.getElementById("possec").innerHTML = data[0][5];
-        document.getElementById("latency").innerHTML = data[0][7];
-        document.getElementById("postotal").innerHTML = data[0][8];
+    const dDisplay = d > 0 ? d + (d === 1 ? " day, " : " days, ") : "";
+    const hDisplay = h > 0 ? h + (h === 1 ? " hour, " : " hours, ") : "";
+    const mDisplay = m > 0 ? m + (m === 1 ? " minute, " : " minutes, ") : "";
+    const sDisplay = s > 0 ? s + (s === 1 ? " second" : " seconds") : "";
+
+    return dDisplay + hDisplay + mDisplay + sDisplay;
+}
+
+/**
+ * Replaces sections of the UUID to obfuscate it.
+ * - Many folks will screenshot this page and share it.
+ * - The UUID identifies the feeder setup, and anybody else copying/using this value could be problematic.
+ */
+function getObfuscatedUuid(uuid) {
+    return uuid === null ?
+        'null' :
+        uuid.split('-')
+            .map((item, i) => (i < 1 || i > 3) ? item : '....')
+            .join('-');
+}
+
+/**
+ * Replaces sections of the IP address to obfuscate it.
+ * - Many folks will screenshot this page and share it.
+ * - The IP address is not particularly sensitive, but it can be PII
+ *   and many users will be hesitant to share it so let's proactively obfuscate it.
+ */
+function getObfuscatedUserIp(userIp) {
+    return userIp
+        .split('.')
+        .map((item, i) => i < 2 ? 'xxx' : item)
+        .join('.');
+}
+
+function statusRowForUuid(data, uuid) {
+
+    const beastData = data.beastData.filter(item => item.uuid === uuid);
+    let beastHtml = `
+    <div class="col-sm">
+      <div class="card">
+        <div class="card-header">
+          <h4><span class="statusdot inactive_feed beastdot"></span> Beast ADS-B</h4>
+        </div>
+        <div class="card-body">
+          <div id="beaststats">
+            <strong>No beast data for this UUID</strong>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+    if(beastData.length === 1) {
+        const beastEntry = beastData[0];
+
+        beastHtml = `
+    <div class="col-sm">
+      <div class="card">
+        <div class="card-header">
+          <h4><span class="statusdot active_feed beastdot"></span> Beast ADS-B</h4>
+        </div>
+        <div class="card-body">
+
+          <div id="beaststats">
+            <ul>
+              <li>Messages: <span id="msgsec">` + beastEntry.messagesPerSecond + `</span>/sec</li>
+              <li>Positions: <span id="possec">` + beastEntry.positionsPerSecond + `</span>/sec</li>
+              <li>Positions total: <span id="postotal">` + beastEntry.positionsTotal + `</span></li>
+              <li>Bandwidth: <span id="bandwidth">` + beastEntry.bandwidthKbps + `</span>kbit/s</li>
+              <li>Latency: <span id="latency">` + beastEntry.latencyMs + `</span>ms</li>
+              <li>Connection time: <span id="latency">` + secondsToDhms(beastEntry.connectionTimeSeconds) + `</span></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>`
     }
 
-    //MLAT data
-    if (data[1] == "No match!") {
-        document.getElementsByClassName("mlatdot")[0].style.backgroundColor = "red";
-        document.getElementById("mlatstats").hidden = true;
-        document.getElementById("mlatstatus").innerHTML = "You are not feeding MLAT data!";
-    } else {
-        document.getElementsByClassName("mlatdot")[0].style.backgroundColor = "green";
-        document.getElementById("mlatstats").hidden = false;
-        document.getElementById("mlatstatus").innerHTML = "You are feeding MLAT data!";
-        document.getElementById("mlatusername").innerHTML = data[1]["user"];
-        document.getElementById("mlatmsgrate").innerHTML = data[1]["message_rate"];
-        document.getElementById("mlatpeers").innerHTML = data[1]["peer_count"];
-        document.getElementById("mlattimeout").innerHTML = data[1]["bad_sync_timeout"];
-        document.getElementById("mlatoutlier").innerHTML = data[1]["outlier_percent"];
+    const mlatData = data.mlatData.filter(item => item.uuid === uuid);
+    let mlatHtml = `
+    <div class="col-sm">
+      <div class="card">
+        <div class="card-header">
+          <h4><span class="statusdot inactive_feed mlatdot"></span> MLAT</h4>
+        </div>
+        <div class="card-body">
+          <div id="mlatstats">
+            <strong>No MLAT data for this UUID</strong>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+    if(mlatData.length === 1) {
+        const mlatEntry = mlatData[0];
+
+        mlatHtml = `
+    <div class="col-sm">
+      <div class="card">
+        <div class="card-header">
+          <h4><span class="statusdot active_feed mlatdot"></span> MLAT</h4>
+        </div>
+        <div class="card-body">
+          <div id="mlatstats">
+            <ul>
+              <li>Name: <span id="mlatusername">` + mlatEntry.user + `</span></li>
+              <li>Messages: <span id="mlatmsgrate">` + mlatEntry.message_rate + `</span>/sec</li>
+              <li>Peers: <span id="mlatpeers">` + mlatEntry.peer_count + `</span></li>
+              <li>Timeout: <span id="mlattimeout">` + mlatEntry.bad_sync_timeout + `</span></li>
+              <li>Outlier %: <span id="mlatoutlier">` + mlatEntry.outlier_percent + `%</span></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>`;
     }
+
+    const obfuscatedUuid = getObfuscatedUuid(uuid);
+    const output = `
+  <div class="row gx-3">
+    <h3>UUID: <code>` + obfuscatedUuid + `</code></h3>
+    ` + beastHtml + `
+    ` + mlatHtml + `
+  </div>`;
+
+    return output;
+}
+
+
+// Function to update both user stats panels
+function updateUserStats(data) {
+    // Show user's IP
+    const userIp = data.ip;
+    const userIpObfuscated = getObfuscatedUserIp(userIp);
+    document.getElementById("userip").innerHTML = userIpObfuscated;
+
+    const statusRows = data.uuids.map(uuid => statusRowForUuid(data, uuid));
+    document.getElementById("status_rows").innerHTML = statusRows.join('\n');
+
 }
 
 // Function to update site feed count data
-function showsitestats(data) {
+function updateSiteStats(data) {
     document.getElementById("beastcount").innerHTML = data[0];
     document.getElementById("mlatcount").innerHTML = data[1];
 }

--- a/html/myip/style.css
+++ b/html/myip/style.css
@@ -4,31 +4,15 @@ img {
   height: auto;
 }
 
-#beaststatspanel {
+.data_panel {
   border-radius: 25px;
   padding: 20px;
   height: auto;
   text-align: left;
   vertical-align: top;
-  background-color: lightgrey;
 }
 
-#beaststatus {
-  margin-top: 20px;
-  text-align: center;
-  font-weight: bold;
-}
-
-#mlatstatspanel {
-  border-radius: 25px;
-  padding: 20px;
-  height: auto;
-  text-align: left;
-  vertical-align: top;
-  background-color: lightgrey;
-}
-
-#mlatstatus {
+.status {
   margin-top: 20px;
   text-align: center;
   font-weight: bold;
@@ -39,18 +23,16 @@ img {
   float: left;
 }
 
-.beastdot {
+.statusdot {
   height: 15px;
   width: 15px;
-  background-color: red;
+  background-color: darkgoldenrod; /* default to an ambiguous colour - JavaScript and the API will override this */
   border-radius: 50%;
   display: inline-block;
 }
-
-.mlatdot {
-  height: 15px;
-  width: 15px;
+.statusdot.active_feed {
+  background-color: green;
+}
+.statusdot.inactive_feed {
   background-color: red;
-  border-radius: 50%;
-  display: inline-block;
 }


### PR DESCRIPTION
Note that this pull request has a hard dependency on changes suggested within:
https://github.com/mpentler/oarc-adsb-api/pull/1

- The pull request on this repository makes use of the newly available collections of data, and displays all UUIDs associated with the IP address the user is connecting from.
  - This includes where a user's setup somehow has multiple UUIDs - for example:
    - ![image](https://github.com/mpentler/oarc-adsb-site/assets/1537214/f907307a-d9b4-46c3-b970-e099ba0cd979)
- Note that in this screenshot the IP address and UUIDs are both obfuscated. 
  - Many users will screenshot and share this page.
  - The UUID identifies the feeder setup, and anybody else copying/using this value could be problematic so should only be shared in specific circumstances where support with server management.
  - The IP address is not particularly sensitive, but it can be PII and many users will be hesitant to share it so let's proactively obfuscate it.