### PR TITLE
Additional error handling and user support messages

### DIFF
--- a/html/myip/index.html
+++ b/html/myip/index.html
@@ -102,9 +102,9 @@
   <div class="row gy-4" id="status_rows">
     <div class="col">
       <p class="alert alert-danger">
-        JavaScript is disabled or there has been an error which prevents JavaScript from running.
+        JavaScript is disabled or there has been an error which prevents JavaScript from updating this page with feed data.
         <br/>
-        Enable JavaScript to view IP stats and/or report suspected issues via the OARC Discord.
+        Enable JavaScript to view IP stats and/or report issues via the OARC Discord.
       </p>
     </div>
   </div>

--- a/html/myip/index.html
+++ b/html/myip/index.html
@@ -108,7 +108,7 @@
         <p>
           Your feed client is sending <code>null</code> as a UUID.</p>
         <p>
-          Where this "<em>unique</em> user ID" (UUID) is not unique between multiple feeders, this can be problematic and risks introducing errors in the data.
+          Where the "<em>unique</em> user ID" (UUID) is not unique between multiple feeders, this can be problematic and risks introducing errors in the data.
         </p>
         <p>
           The easiest remedy is to update your OARC ADSB installation

--- a/html/myip/index.html
+++ b/html/myip/index.html
@@ -99,6 +99,25 @@
     </div>
   </div>
 
+  <div class="row mb-4 d-none" id="null_uuid_alert">
+    <div class="col-sm">
+      <div class="alert alert-danger" role="alert">
+        <h3>
+          Update your OARC ADSB feed client!
+        </h3>
+        <p>
+          Your feed client is sending <code>null</code> as a UUID.</p>
+        <p>
+          Where this "<em>unique</em> user ID" (UUID) is not unique between multiple feeders, this can be problematic and risks introducing errors in the data.
+        </p>
+        <p>
+          The easiest remedy is to update your OARC ADSB installation
+          (<a href="https://github.com/mpentler/oarc-adsb-scripts/#update-the-feed-client-without-reconfiguring" class="alert-link">guide to update without reconfiguring</a>).
+        </p>
+      </div>
+    </div>
+  </div>
+
   <div class="row gy-4" id="status_rows">
     <div class="col">
       <p class="alert alert-danger">

--- a/html/myip/index.html
+++ b/html/myip/index.html
@@ -81,6 +81,24 @@
     </div>
   </div>
 
+  <div class="row mb-4 d-none" id="update_oarc_client_alert">
+    <div class="col-sm">
+      <div class="alert alert-warning" role="alert">
+        <h3>
+          Update your OARC ADSB feed client!
+        </h3>
+        <p>
+          Beast and MLAT data is being sent with different UUIDs.
+          Recent versions of the installation script will use the same UUID for both Beast and MLAT data.
+        </p>
+        <p>
+          To have Beast and MLAT data fed to OARC with the same UUID, run the update script
+          (<a href="https://github.com/mpentler/oarc-adsb-scripts/#update-the-feed-client-without-reconfiguring" class="alert-link">guide to update without reconfiguring</a>).
+        </p>
+      </div>
+    </div>
+  </div>
+
   <div class="row gy-4" id="status_rows">
     <div class="col">
       <p class="alert alert-danger">
@@ -112,14 +130,14 @@
     - This code segment actually "does stuff" / calls the functions.
   */
 
-  // // URLs to the API data - these two relative URLs are useful for testing locally
-  // // if you paste a copy of the API output in your working directory.
-  // const apiUrlIp = 'myip_v4.json';
-  // const apiUrlFeedCount = 'feedcount.json';
+  // URLs to the API data - these two relative URLs are useful for testing locally
+  // if you paste a copy of the API output in your working directory.
+  const apiUrlIp = 'myip_v4.json';
+  const apiUrlFeedCount = 'feedcount.json';
 
-  // URLs to the API data - these are the real URLs for the live site.
-  const apiUrlIp = 'https://adsb.oarc.uk/api/v4/myip';
-  const apiUrlFeedCount = 'https://adsb.oarc.uk/api/v3/feedcount';
+  // // URLs to the API data - these are the real URLs for the live site.
+  // const apiUrlIp = 'https://adsb.oarc.uk/api/v4/myip';
+  // const apiUrlFeedCount = 'https://adsb.oarc.uk/api/v3/feedcount';
 
   // Trigger the first update ASAP
   getApiData(apiUrlIp, apiUrlFeedCount);

--- a/html/myip/index.js
+++ b/html/myip/index.js
@@ -244,6 +244,10 @@ function updateUserStats(data) {
     if (data.uuids.length === 2 && data.beastData.length === 1 && data.mlatData.length === 1) {
         document.getElementById('update_oarc_client_alert').classList.remove('d-none');
     }
+    // If a null UUID is present, this is potentially problematic and the user should be alerted.
+    if(data.uuids.includes(null)) {
+        document.getElementById('null_uuid_alert').classList.remove('d-none');
+    }
 
     let statusRows = [noDataToDisplay()];
     if (data.uuids.length > 0) {

--- a/html/myip/index.js
+++ b/html/myip/index.js
@@ -161,6 +161,11 @@ function updateUserStats(data) {
     const userIpObfuscated = getObfuscatedUserIp(userIp);
     document.getElementById("userip").innerHTML = userIpObfuscated;
 
+    // If two UUIDs, one for Beast and one for MLAT, then this is likely an old OARC installation.
+    if(data.uuids.length === 2 && data.beastData.length === 1 && data.mlatData.length === 1) {
+        document.getElementById('update_oarc_client_alert').classList.remove('d-none');
+    }
+
     const statusRows = data.uuids.map(uuid => statusRowForUuid(data, uuid));
     document.getElementById("status_rows").innerHTML = statusRows.join('\n');
 

--- a/html/myip/index.js
+++ b/html/myip/index.js
@@ -152,7 +152,7 @@ function statusRowForUuid(data, uuid) {
 
     return output;
 }
-function noDataToDisplay() {
+function noDataToDisplayForThisIpAddress() {
     let beastHtml = `
     <div class="col">
       <div class="card border-danger">
@@ -161,7 +161,7 @@ function noDataToDisplay() {
         </div>
         <div class="card-body border-danger">
           <div id="beaststats">
-            <strong>No beast data for this UUID</strong>
+            <strong>No beast data for this IP address</strong>
           </div>
         </div>
       </div>
@@ -176,7 +176,7 @@ function noDataToDisplay() {
         </div>
         <div class="card-body">
           <div id="mlatstats">
-            <strong>No MLAT data for this UUID</strong>
+            <strong>No MLAT data for this IP address</strong>
           </div>
         </div>
       </div>
@@ -249,7 +249,7 @@ function updateUserStats(data) {
         document.getElementById('null_uuid_alert').classList.remove('d-none');
     }
 
-    let statusRows = [noDataToDisplay()];
+    let statusRows = [noDataToDisplayForThisIpAddress()];
     if (data.uuids.length > 0) {
         console.info('uuids present...')
         statusRows = data.uuids.map(uuid => statusRowForUuid(data, uuid));

--- a/html/myip/index.js
+++ b/html/myip/index.js
@@ -63,11 +63,11 @@ function getObfuscatedUserIp(userIp) {
 function statusRowForUuid(data, uuid) {
 
     const beastData = data.beastData.filter(item => item.uuid === uuid);
-    let beastHtml = `
-    <div class="col-sm">
-      <div class="card">
+    let beastColHtml = `
+    <div class="col">
+      <div class="card border-danger">
         <div class="card-header">
-          <h4><span class="statusdot inactive_feed beastdot"></span> Beast ADS-B</h4>
+          <h4 class="card-title"><span class="statusdot inactive_feed beastdot"></span> Beast ADS-B</h4>
         </div>
         <div class="card-body">
           <div id="beaststats">
@@ -77,14 +77,14 @@ function statusRowForUuid(data, uuid) {
       </div>
     </div>`;
 
-    if(beastData.length === 1) {
+    if (beastData.length === 1) {
         const beastEntry = beastData[0];
 
-        beastHtml = `
-    <div class="col-sm">
+        beastColHtml = `
+    <div class="col">
       <div class="card">
         <div class="card-header">
-          <h4><span class="statusdot active_feed beastdot"></span> Beast ADS-B</h4>
+          <h4 class="card-title"><span class="statusdot active_feed beastdot"></span> Beast ADS-B</h4>
         </div>
         <div class="card-body">
 
@@ -104,11 +104,11 @@ function statusRowForUuid(data, uuid) {
     }
 
     const mlatData = data.mlatData.filter(item => item.uuid === uuid);
-    let mlatHtml = `
-    <div class="col-sm">
-      <div class="card">
+    let mlatColHtml = `
+    <div class="col">
+      <div class="card border-danger">
         <div class="card-header">
-          <h4><span class="statusdot inactive_feed mlatdot"></span> MLAT</h4>
+          <h4 class="card-title"><span class="statusdot inactive_feed mlatdot"></span> MLAT</h4>
         </div>
         <div class="card-body">
           <div id="mlatstats">
@@ -118,14 +118,14 @@ function statusRowForUuid(data, uuid) {
       </div>
     </div>`;
 
-    if(mlatData.length === 1) {
+    if (mlatData.length === 1) {
         const mlatEntry = mlatData[0];
 
-        mlatHtml = `
-    <div class="col-sm">
+        mlatColHtml = `
+    <div class="col">
       <div class="card">
         <div class="card-header">
-          <h4><span class="statusdot active_feed mlatdot"></span> MLAT</h4>
+          <h4 class="card-title"><span class="statusdot active_feed mlatdot"></span> MLAT</h4>
         </div>
         <div class="card-body">
           <div id="mlatstats">
@@ -144,8 +144,87 @@ function statusRowForUuid(data, uuid) {
 
     const obfuscatedUuid = getObfuscatedUuid(uuid);
     const output = `
-  <div class="row gx-3">
+  <div class="row gx-3 mt-3">
     <h3>UUID: <code>` + obfuscatedUuid + `</code></h3>
+    ` + beastColHtml + `
+    ` + mlatColHtml + `
+  </div>`;
+
+    return output;
+}
+function noDataToDisplay() {
+    let beastHtml = `
+    <div class="col">
+      <div class="card border-danger">
+        <div class="card-header">
+          <h4 class="card-title"><span class="statusdot inactive_feed beastdot"></span> Beast ADS-B</h4>
+        </div>
+        <div class="card-body border-danger">
+          <div id="beaststats">
+            <strong>No beast data for this UUID</strong>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+
+    let mlatHtml = `
+    <div class="col">
+      <div class="card border-danger">
+        <div class="card-header">
+          <h4 class="card-title"><span class="statusdot inactive_feed mlatdot"></span> MLAT</h4>
+        </div>
+        <div class="card-body">
+          <div id="mlatstats">
+            <strong>No MLAT data for this UUID</strong>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+    const noData = `
+    <div class="col mb-4">
+        <div class="card">
+            <div class="card-header bg-light">
+                <h3 class="card-title"><span class="statusdot inactive_feed mlatdot"></span> No ADSB data for this IP address</h3>
+            </div>
+            <div class="card-body">
+                <p>
+                    <h4>Getting Started</h4>
+                </p>
+                <p>
+                    If you do not yet have an ADSB system setup to feed data to the OARC ADSB server, you will need:
+                </p>
+                <ol>
+                    <li><strong>Hardware</strong> - a Raspberry Pi or similar, with an antenna and SDR to recieve radio signals</li>
+                    <li><strong>Software</strong> - to interpret radio signals and convert them to digital/textual ADSB data (recommended: <code>readsb</code>, installed using <a href="https://github.com/mpentler/oarc-adsb-scripts/">the OARC installation scripts</a>)</li>
+                    <li><strong>OARC-specific configuration</strong> - to send ADSB data to the OARC server, see the <a href="https://github.com/mpentler/oarc-adsb-scripts/">installation script documentaton</a> for details</li>
+                </ol>
+                <p>
+                    <h4>Troubleshooting tips</h4>
+                </p>
+                <p>
+                    If you have an ADSB feed setup, but are not seeing data:
+                </p>
+                <ul>
+                    <li><strong>IP Address match</strong> - Are you connecting from a network which is different to your feeder's network (e.g., 4G or via VPN)?</li>
+                    <li><strong>Feed running correctly</strong> - See notes within the <a href="https://github.com/mpentler/oarc-adsb-scripts/">script documentation</a> for log and support information</li>
+                </ul>
+                <p>
+                    <h4>Learning more / Additional support</h4>
+                </p>
+                <ul>
+                    <li>The OARC community welcomes discussion via the ADSB Discord channel - <code>#adsb-flight-tracking</code></li>
+                    <li>Also available is the <a href="https://wiki.oarc.uk/flight:adsb">OARC Wiki pages</a> which contain more more guidance and information about ADSB</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+`;
+
+    const output = `
+    ` + noData + `
+  <div class="row gx-3">
     ` + beastHtml + `
     ` + mlatHtml + `
   </div>`;
@@ -162,12 +241,17 @@ function updateUserStats(data) {
     document.getElementById("userip").innerHTML = userIpObfuscated;
 
     // If two UUIDs, one for Beast and one for MLAT, then this is likely an old OARC installation.
-    if(data.uuids.length === 2 && data.beastData.length === 1 && data.mlatData.length === 1) {
+    if (data.uuids.length === 2 && data.beastData.length === 1 && data.mlatData.length === 1) {
         document.getElementById('update_oarc_client_alert').classList.remove('d-none');
     }
 
-    const statusRows = data.uuids.map(uuid => statusRowForUuid(data, uuid));
-    document.getElementById("status_rows").innerHTML = statusRows.join('\n');
+    let statusRows = [noDataToDisplay()];
+    if (data.uuids.length > 0) {
+        console.info('uuids present...')
+        statusRows = data.uuids.map(uuid => statusRowForUuid(data, uuid));
+    }
+
+    document.getElementById("status_rows").innerHTML = '<div class="col">' + statusRows.join('\n') + '</div>';
 
 }
 


### PR DESCRIPTION
**Changes**

This pull request introduces some help/guidance/nudges where we are not able to provide full data / stats about the current IP's feeder.

1. **Display support and guidance where no data is found for the current IP address**
   - This includes brief guidance for folk who do not yet have a feed
   - ... and people who have a feed setup but are troubleshooting to find out why their data is not visible
   - Screenshot
     - ![image](https://github.com/mpentler/oarc-adsb-site/assets/1537214/c5ff7f01-bc9a-43dd-9684-bba8eae388ac)
2. **Display a nudge for folk with non-matching UUIDs**
   - Where there are precisely two UUIDs present, with one attached to Beast data and the other attached to MLAT data, display a nudge for users to update their OARC ADSB installation which will combine the two feeds under a single UUID
   - Screenshot: 
     - ![image](https://github.com/mpentler/oarc-adsb-site/assets/1537214/2c1bc011-8ede-4a95-9de6-e5fe3b7c179c)
3. **Display an error message where a UUID is `null`**
   - `null` UUIDs are more urgent/problematic than non-aligned UUIDs and they risk tripping up any code which expects this to be unique to the feed (`null` is substantially more likely to be accidentally shared between feeders)
   - ... therefore this message is displayed as a warning and a very strong recommendation to update
   - Screenshot:
     - ![image](https://github.com/mpentler/oarc-adsb-site/assets/1537214/a3f47871-8c72-43b4-98c4-2799d45f127a)


