### PR TITLE
Display both current and historical alerts

### DIFF
--- a/html/emergencies/index.html
+++ b/html/emergencies/index.html
@@ -45,7 +45,7 @@
         <a class="nav-link" href="https://adsb.oarc.uk/graphs1090/">System Graphs</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="#">Emergency Log  <span class="sr-only">(current)</span></a>
+        <a class="nav-link" href="#">Emergency Log <span class="sr-only">(current)</span></a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://wiki.oarc.uk/flight:adsb" target="_blank">ADS-B @ OARC Wiki (new window)</a>
@@ -68,17 +68,41 @@
   </div>
 </div>
 
-<table data-toggle="table" data-url="emergencies.json">
-  <thead>
+<div class="row mt-4">
+  <h3>Current alerts</h3>
+  <table data-toggle="table" data-url="emergencies.json">
+    <thead>
     <tr>
       <th data-field="flight">Callsign</th>
       <th data-field="hex">ICAO Hex</th>
-      <th data-field="detected">Detected</th>
       <th data-field="squawk">Squawk</th>
+      <th data-field="alert_detected">Alert Detected</th>
+      <th data-field="alert_last_seen">Alert Last Seen</th>
+      <th data-field="alert_detection_stopped">Alert Stopped</th>
+      <th data-field="alert_status">Alert Status</th>
       <th data-field="link" data-formatter="LinkFormatter">Link</th>
     </tr>
-  </thead>
-</table>
+    </thead>
+  </table>
+</div>
+
+<div class="row mt-4">
+  <h3>Historical alerts</h3>
+  <table data-toggle="table" data-url="emergencies_history.json">
+    <thead>
+    <tr>
+      <th data-field="flight">Callsign</th>
+      <th data-field="hex">ICAO Hex</th>
+      <th data-field="squawk">Squawk</th>
+      <th data-field="alert_detected">Alert Detected</th>
+      <th data-field="alert_last_seen">Alert Last Seen</th>
+      <th data-field="alert_detection_stopped">Alert Stopped</th>
+      <th data-field="alert_status">Alert Status</th>
+      <th data-field="link" data-formatter="LinkFormatter">Link</th>
+    </tr>
+    </thead>
+  </table>
+</div>
 
 </body>
 


### PR DESCRIPTION
Probably a bit more opportunity to make it look pretty but this works to display data from both `emergencies.json` and `emergencies_history.json`

Screenshot showing an example using fake data:

![image](https://github.com/mpentler/oarc-adsb-site/assets/1537214/2258064e-6abd-4a29-9e60-c7219a9ecca9)
