### PR TITLE
Make the emergencies page pretty with pagination and sorting and descriptive data values etc

### DIFF
--- a/html/emergencies/index.html
+++ b/html/emergencies/index.html
@@ -2,19 +2,14 @@
 <html lang="en">
 
 <head>
-<title>OARC ADS-B Tracker - Emergency Log</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-<link rel="stylesheet" href="style.css">
-<link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.css">
+  <title>OARC ADS-B Tracker - Emergency Log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.css">
 </head>
 
 <body>
-<script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.js"></script>
-<script src="index.js"></script>
 
 <div id="toplogo"><img src="topbanner.png" alt="top banner logo"></div>
 
@@ -45,7 +40,7 @@
         <a class="nav-link" href="https://adsb.oarc.uk/graphs1090/">System Graphs</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="#">Emergency Log <span class="sr-only">(current)</span></a>
+        <a class="nav-link" href="#">Emergency Log  <span class="sr-only">(current)</span></a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://wiki.oarc.uk/flight:adsb" target="_blank">ADS-B @ OARC Wiki (new window)</a>
@@ -68,41 +63,67 @@
   </div>
 </div>
 
-<div class="row mt-4">
-  <h3>Current alerts</h3>
-  <table data-toggle="table" data-url="emergencies.json">
-    <thead>
-    <tr>
-      <th data-field="flight">Callsign</th>
-      <th data-field="hex">ICAO Hex</th>
-      <th data-field="squawk">Squawk</th>
-      <th data-field="alert_detected">Alert Detected</th>
-      <th data-field="alert_last_seen">Alert Last Seen</th>
-      <th data-field="alert_detection_stopped">Alert Stopped</th>
-      <th data-field="alert_status">Alert Status</th>
-      <th data-field="link" data-formatter="LinkFormatter">Link</th>
-    </tr>
-    </thead>
-  </table>
+<div class="container">
+
+  <div class="row mt-4">
+    <h3>Current alerts</h3>
+    <table
+      data-toggle="table"
+      data-url="emergencies.json"
+      data-page-list="[10, 25, 50, 100, all]"
+      data-pagination="true"
+      data-show-export="true"
+      data-search="true"
+      data-sortable="true"
+    >
+      <thead>
+      <tr>
+        <th data-field="flight"                    data-align="center"    data-sortable="true"     data-formatter="callsignFormatter"       >Callsign</th>
+        <th data-field="hex"                       data-align="center"    data-sortable="true"     data-formatter="icaoHexFormatter"        >ICAO Hex</th>
+        <th data-field="squawk"                    data-align="center"    data-sortable="true"     data-formatter="squawkFormatter"         >Squawk</th>
+        <th data-field="alert_detected"            data-align="center"    data-sortable="true"     data-formatter="detectedFormatter"       >Alert Detected</th>
+        <th data-field="alert_last_seen"           data-align="center"    data-sortable="true"     data-formatter="lastSeenFormatter"       >Alert Last Seen</th>
+        <th data-field="alert_detection_stopped"   data-align="center"    data-sortable="true"     data-formatter="alertStoppedFormatter"   >Alert Stopped</th>
+        <th data-field="alert_status"              data-align="center"                                                                      >Alert Status</th>
+        <th data-field="link"                      data-align="center"                             data-formatter="LinkFormatter"           >Link</th>
+      </tr>
+      </thead>
+    </table>
+  </div>
+
+  <div class="row mt-4">
+    <h3>Historical alerts</h3>
+    <table
+      data-toggle="table"
+      data-url="emergencies_history.json"
+      data-page-list="[10, 25, 50, 100, all]"
+      data-pagination="true"
+      data-show-export="true"
+      data-search="true"
+      data-sortable="true"
+    >
+      <thead>
+      <tr>
+        <th data-field="flight"                    data-align="center"    data-sortable="true"     data-formatter="callsignFormatter"       >Callsign</th>
+        <th data-field="hex"                       data-align="center"    data-sortable="true"     data-formatter="icaoHexFormatter"        >ICAO Hex</th>
+        <th data-field="squawk"                    data-align="center"    data-sortable="true"     data-formatter="squawkFormatter"         >Squawk</th>
+        <th data-field="alert_detected"            data-align="center"    data-sortable="true"     data-formatter="detectedFormatter"       >Alert Detected</th>
+        <th data-field="alert_last_seen"           data-align="center"    data-sortable="true"     data-formatter="lastSeenFormatter"       >Alert Last Seen</th>
+        <th data-field="alert_detection_stopped"   data-align="center"    data-sortable="true"     data-formatter="alertStoppedFormatter"   >Alert Stopped</th>
+        <th data-field="alert_status"              data-align="center"                                                                      >Alert Status</th>
+        <th data-field="link"                      data-align="center"                             data-formatter="LinkFormatter"           >Link</th>
+      </tr>
+      </thead>
+    </table>
+  </div>
 </div>
 
-<div class="row mt-4">
-  <h3>Historical alerts</h3>
-  <table data-toggle="table" data-url="emergencies_history.json">
-    <thead>
-    <tr>
-      <th data-field="flight">Callsign</th>
-      <th data-field="hex">ICAO Hex</th>
-      <th data-field="squawk">Squawk</th>
-      <th data-field="alert_detected">Alert Detected</th>
-      <th data-field="alert_last_seen">Alert Last Seen</th>
-      <th data-field="alert_detection_stopped">Alert Stopped</th>
-      <th data-field="alert_status">Alert Status</th>
-      <th data-field="link" data-formatter="LinkFormatter">Link</th>
-    </tr>
-    </thead>
-  </table>
-</div>
+
+<script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.js"></script>
+<script src="index.js"></script>
 
 </body>
 

--- a/html/emergencies/index.js
+++ b/html/emergencies/index.js
@@ -10,14 +10,14 @@ function icaoHexFormatter(value, row, index) {
     return '<code>' + value + '</code>';
 }
 
-function squawkFormatter(value, row, index) {
-    var squawkDescriptions = {
-        7500: 'Unlawful interference',
-        7600: 'Lost communications',
-        7700: 'General emergency'
-    };
+const squawkDescriptions = {
+    7500: 'Unlawful interference',
+    7600: 'Lost communications',
+    7700: 'General emergency'
+};
 
-    var description = squawkDescriptions[value];
+function squawkFormatter(value, row, index) {
+    const description = squawkDescriptions[value];
     if (description === undefined) {
         return '<code>' + value + '</code>';
     }
@@ -35,6 +35,7 @@ function lastSeenFormatter(value, row, index) {
 
     return '<span title="' + lastSeen + '">' + lastSeen.toLocaleString() + '<br/>' + ' ' + '<small>' + '(since first detection: ' + humanReadableTimeDuration(detected, lastSeen) + ')' + '</small>' + '</span>';
 }
+
 function alertStoppedFormatter(value, row, index) {
     const detected = new Date(row.alert_detected);
     const stopped = new Date(value);
@@ -51,7 +52,7 @@ function humanReadableTimeDuration(start, end) {
     let val = '';
     if (diffHours > 0) {
         val += diffHours + ' hour';
-        if(diffHours > 1) {
+        if (diffHours > 1) {
             val += 's';
         }
     }
@@ -61,7 +62,7 @@ function humanReadableTimeDuration(start, end) {
             val += ', ';
         }
         val += diffMinutes + ' minute';
-        if(diffMinutes > 1) {
+        if (diffMinutes > 1) {
             val += 's';
         }
     }
@@ -71,7 +72,7 @@ function humanReadableTimeDuration(start, end) {
             val += ', ';
         }
         val += diffSeconds + ' second';
-        if(diffSeconds > 1) {
+        if (diffSeconds > 1) {
             val += 's';
         }
     }

--- a/html/emergencies/index.js
+++ b/html/emergencies/index.js
@@ -1,3 +1,73 @@
 function LinkFormatter(value, row, index) {
-  return '<a href="'+row.link+'">Follow</a>';
+    return '<a href="' + row.link + '">Follow</a>';
 }
+
+function callsignFormatter(value, row, index) {
+    return '<code>' + value + '</code>';
+}
+
+function icaoHexFormatter(value, row, index) {
+    return '<code>' + value + '</code>';
+}
+
+function squawkFormatter(value, row, index) {
+    var squawkDescriptions = {
+        7500: 'Unlawful interference',
+        7600: 'Lost communications',
+        7700: 'General emergency'
+    };
+
+    var description = squawkDescriptions[value];
+    if (description === undefined) {
+        return '<code>' + value + '</code>';
+    }
+    return '<code>' + value + '</code> ' + '<br/>' + '<small>' + description + '</small>';
+}
+
+function detectedFormatter(value, row, index) {
+    const detected = new Date(value);
+    return '<span title="' + value + '">' + detected.toLocaleString() + '</span>';
+}
+
+function lastSeenFormatter(value, row, index) {
+    const detected = new Date(row.alert_detected);
+    const lastSeen = new Date(value);
+
+    return '<span title="' + lastSeen + '">' + lastSeen.toLocaleString() + '<br/>' + ' ' + '<small>' + '(since first detection: ' + humanReadableTimeDuration(detected, lastSeen) + ')' + '</small>' + '</span>';
+}
+function alertStoppedFormatter(value, row, index) {
+    const detected = new Date(row.alert_detected);
+    const stopped = new Date(value);
+
+    return '<span title="' + stopped + '">' + value + '<br/>' + ' ' + '<small>' + '(since first detection: ' + humanReadableTimeDuration(detected, stopped) + ')' + '</small>' + '</span>';
+}
+
+// hh hours, mm minutes, ss seconds
+function humanReadableTimeDuration(start, end) {
+    const diffMs = end - start;
+    const diffHours = Math.floor(diffMs / 1000 / 60 / 60);
+    const diffMinutes = Math.floor(diffMs / 1000 / 60) - diffHours * 60;
+    const diffSeconds = Math.floor(diffMs / 1000) - diffHours * 60 * 60 - diffMinutes * 60;
+
+    let val = '';
+    if (diffHours > 0) {
+        val += diffHours + ' hours';
+    }
+
+    if (diffMinutes > 0) {
+        if (val.length > 0) {
+            val += ', ';
+        }
+        val += diffMinutes + ' minutes';
+    }
+
+    if (diffSeconds > 0 || val === '') {
+        if (val.length > 0) {
+            val += ', ';
+        }
+        val += diffSeconds + ' seconds';
+    }
+
+    return val;
+}
+

--- a/html/emergencies/index.js
+++ b/html/emergencies/index.js
@@ -40,7 +40,7 @@ function alertStoppedFormatter(value, row, index) {
     const detected = new Date(row.alert_detected);
     const stopped = new Date(value);
 
-    return '<span title="' + stopped + '">' + value + '<br/>' + ' ' + '<small>' + '(since first detection: ' + humanReadableTimeDuration(detected, stopped) + ')' + '</small>' + '</span>';
+    return '<span title="' + stopped + '">' + stopped.toLocaleString() + '<br/>' + ' ' + '<small>' + '(since first detection: ' + humanReadableTimeDuration(detected, stopped) + ')' + '</small>' + '</span>';
 }
 
 function humanReadableTimeDuration(start, end) {

--- a/html/emergencies/index.js
+++ b/html/emergencies/index.js
@@ -42,7 +42,6 @@ function alertStoppedFormatter(value, row, index) {
     return '<span title="' + stopped + '">' + value + '<br/>' + ' ' + '<small>' + '(since first detection: ' + humanReadableTimeDuration(detected, stopped) + ')' + '</small>' + '</span>';
 }
 
-// hh hours, mm minutes, ss seconds
 function humanReadableTimeDuration(start, end) {
     const diffMs = end - start;
     const diffHours = Math.floor(diffMs / 1000 / 60 / 60);
@@ -51,21 +50,30 @@ function humanReadableTimeDuration(start, end) {
 
     let val = '';
     if (diffHours > 0) {
-        val += diffHours + ' hours';
+        val += diffHours + ' hour';
+        if(diffHours > 1) {
+            val += 's';
+        }
     }
 
     if (diffMinutes > 0) {
         if (val.length > 0) {
             val += ', ';
         }
-        val += diffMinutes + ' minutes';
+        val += diffMinutes + ' minute';
+        if(diffMinutes > 1) {
+            val += 's';
+        }
     }
 
     if (diffSeconds > 0 || val === '') {
         if (val.length > 0) {
             val += ', ';
         }
-        val += diffSeconds + ' seconds';
+        val += diffSeconds + ' second';
+        if(diffSeconds > 1) {
+            val += 's';
+        }
     }
 
     return val;


### PR DESCRIPTION
Now that we've got the emergency data being stored and displayed, this PR adjusts the output tables to make it look pretty and to include some additional annotations/inline information.

Credit for the table implementation goes to the [javascript table library](https://examples.bootstrap-table.com/) which allows for a lot of configuration options out of the box!

Screenshot showing the table (whole bunch of fake/duplicated json entries to show the pagination):

![image](https://github.com/mpentler/oarc-adsb-site/assets/1537214/a40abb2b-eac4-4a60-980e-347256067f57)
